### PR TITLE
Simplify validator api

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,23 @@ Poetry is required to locally run the tests for this library
 <!-- USAGE EXAMPLES -->
 ## Example
 ```python
+from google.protobuf.descriptor import FieldDescriptor
 from grpc_argument_validator import validate_args
-from grpc_argument_validator import AbstractArgumentValidator
+from grpc_argument_validator import AbstractArgumentValidator, ValidationResult
 
 class PathValidator(AbstractArgumentValidator):
-    def is_valid(self, value: Path, field_descriptor) -> bool:
-        return len(value.points) > 5
 
-    def invalid_message(self, name: str) -> str:
-        return f"path for '{name}' should be at least five points long"
+    def check(self, name: str, value: Path, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if len(value.points) > 5:
+            return ValidationResult(valid=True)
+        return ValidationResult(False, f"path for '{name}' should be at least five points long")
 
-class RouteChecker(RouteCheckerServicer):
+class RouteService(RouteCheckerServicer):
     @validate_args(
         non_empty=["tags", "tags[]", "path.points"],
         validators={"path": PathValidator()},
     )
-    def Check(self, request: Route, context: grpc.ServicerContext):
+    def Create(self, request: Route, context: grpc.ServicerContext):
         return BoolValue(value=True)
 ```
 

--- a/docs/grpc_argument_validator/argument_validators.html
+++ b/docs/grpc_argument_validator/argument_validators.html
@@ -30,8 +30,22 @@
 import re
 import typing
 import uuid
+from dataclasses import dataclass
 
 from google.protobuf.descriptor import FieldDescriptor
+
+
+@dataclass
+class ValidationResult:
+    &#34;&#34;&#34;
+    Contains results for validation check.
+    &#34;&#34;&#34;
+
+    valid: bool
+    &#34;&#34;&#34;Whether the argument was valid.&#34;&#34;&#34;
+
+    invalid_reason: typing.Optional[str] = None
+    &#34;&#34;&#34;Reason for invalidity of the argument. Will be ``None`` if valid.&#34;&#34;&#34;
 
 
 class AbstractArgumentValidator(abc.ABC):
@@ -40,29 +54,17 @@ class AbstractArgumentValidator(abc.ABC):
     &#34;&#34;&#34;
 
     @abc.abstractmethod
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
         &#34;&#34;&#34;
         Returns a validation bool of the given value and field_descriptor
 
             Parameters:
+                name (str): Name for the field to be used in invalid reason messages.
                 value (typing.Any): The value to be validated
                 field_descriptor (FieldDescriptor): The protobuf field descriptor of the given value
 
             Returns:
-                is_valid (bool): validation bool for the given value
-        &#34;&#34;&#34;
-        pass
-
-    @abc.abstractmethod
-    def invalid_message(self, name: str) -&gt; str:
-        &#34;&#34;&#34;
-        Returns a validation message for the given field name
-
-            Parameters:
-                name (str): Name of the validated field
-
-            Returns:
-                message (str): message describing the constraints of the validator
+                result (ValidationResult): validation bool for the given value
         &#34;&#34;&#34;
         pass
 
@@ -70,48 +72,47 @@ class AbstractArgumentValidator(abc.ABC):
 class UUIDBytesValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Class that ensures the provided value is a valid UUID&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
         try:
             uuid.UUID(bytes=value)
         except (ValueError, TypeError):
-            return False
-        return True
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must be a valid UUID&#34;
+            return ValidationResult(False, f&#34;{name} must be a valid UUID&#34;)
+        return ValidationResult(True)
 
 
 class NonDefaultValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Ensures the provided value is not the default value for this field type&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return value != field_descriptor.default_value
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must have non-default value&#34;
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if value != field_descriptor.default_value:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must have non-default value&#34;)
 
 
 class NonEmptyValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Ensures the provided value is non-empty&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return len(value) &gt; 0
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must be non-empty&#34;
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if len(value) &gt; 0:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must be non-empty&#34;)
 
 
 class RegexpValidator(AbstractArgumentValidator):
-    &#34;&#34;&#34;Matches the input value against the provided regex&#34;&#34;&#34;
+    &#34;&#34;&#34;
+    Matches the input value against the provided regex.
+
+    Parameters:
+        pattern (str): Regexp pattern to match.
+    &#34;&#34;&#34;
 
     def __init__(self, pattern: str):
         self._pattern = pattern
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return re.match(self._pattern, value) is not None
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must match regexp pattern: {self._pattern}&#34;</code></pre>
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if re.match(self._pattern, value) is not None:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must match regexp pattern: {self._pattern}&#34;)</code></pre>
 </details>
 </section>
 <section>
@@ -138,29 +139,17 @@ class RegexpValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;
 
     @abc.abstractmethod
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
         &#34;&#34;&#34;
         Returns a validation bool of the given value and field_descriptor
 
             Parameters:
+                name (str): Name for the field to be used in invalid reason messages.
                 value (typing.Any): The value to be validated
                 field_descriptor (FieldDescriptor): The protobuf field descriptor of the given value
 
             Returns:
-                is_valid (bool): validation bool for the given value
-        &#34;&#34;&#34;
-        pass
-
-    @abc.abstractmethod
-    def invalid_message(self, name: str) -&gt; str:
-        &#34;&#34;&#34;
-        Returns a validation message for the given field name
-
-            Parameters:
-                name (str): Name of the validated field
-
-            Returns:
-                message (str): message describing the constraints of the validator
+                result (ValidationResult): validation bool for the given value
         &#34;&#34;&#34;
         pass</code></pre>
 </details>
@@ -177,62 +166,35 @@ class RegexpValidator(AbstractArgumentValidator):
 </ul>
 <h3>Methods</h3>
 <dl>
-<dt id="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message"><code class="name flex">
-<span>def <span class="ident">invalid_message</span></span>(<span>self, name: str) ‑> str</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Returns a validation message for the given field name</p>
-<pre><code>Parameters:
-    name (str): Name of the validated field
-
-Returns:
-    message (str): message describing the constraints of the validator
-</code></pre></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@abc.abstractmethod
-def invalid_message(self, name: str) -&gt; str:
-    &#34;&#34;&#34;
-    Returns a validation message for the given field name
-
-        Parameters:
-            name (str): Name of the validated field
-
-        Returns:
-            message (str): message describing the constraints of the validator
-    &#34;&#34;&#34;
-    pass</code></pre>
-</details>
-</dd>
-<dt id="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid"><code class="name flex">
-<span>def <span class="ident">is_valid</span></span>(<span>self, value: Any, field_descriptor: google.protobuf.descriptor.FieldDescriptor) ‑> bool</span>
+<dt id="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check"><code class="name flex">
+<span>def <span class="ident">check</span></span>(<span>self, name: str, value: Any, field_descriptor: google.protobuf.descriptor.FieldDescriptor) ‑> <a title="grpc_argument_validator.argument_validators.ValidationResult" href="#grpc_argument_validator.argument_validators.ValidationResult">ValidationResult</a></span>
 </code></dt>
 <dd>
 <div class="desc"><p>Returns a validation bool of the given value and field_descriptor</p>
 <pre><code>Parameters:
+    name (str): Name for the field to be used in invalid reason messages.
     value (typing.Any): The value to be validated
     field_descriptor (FieldDescriptor): The protobuf field descriptor of the given value
 
 Returns:
-    is_valid (bool): validation bool for the given value
+    result (ValidationResult): validation bool for the given value
 </code></pre></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">@abc.abstractmethod
-def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
+def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
     &#34;&#34;&#34;
     Returns a validation bool of the given value and field_descriptor
 
         Parameters:
+            name (str): Name for the field to be used in invalid reason messages.
             value (typing.Any): The value to be validated
             field_descriptor (FieldDescriptor): The protobuf field descriptor of the given value
 
         Returns:
-            is_valid (bool): validation bool for the given value
+            result (ValidationResult): validation bool for the given value
     &#34;&#34;&#34;
     pass</code></pre>
 </details>
@@ -251,11 +213,10 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <pre><code class="python">class NonDefaultValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Ensures the provided value is not the default value for this field type&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return value != field_descriptor.default_value
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must have non-default value&#34;</code></pre>
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if value != field_descriptor.default_value:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must have non-default value&#34;)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -266,8 +227,7 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <ul class="hlist">
 <li><code><b><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a></b></code>:
 <ul class="hlist">
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message">invalid_message</a></code></li>
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid">is_valid</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.check">check</a></code></li>
 </ul>
 </li>
 </ul>
@@ -284,11 +244,10 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <pre><code class="python">class NonEmptyValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Ensures the provided value is non-empty&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return len(value) &gt; 0
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must be non-empty&#34;</code></pre>
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if len(value) &gt; 0:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must be non-empty&#34;)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -299,8 +258,7 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <ul class="hlist">
 <li><code><b><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a></b></code>:
 <ul class="hlist">
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message">invalid_message</a></code></li>
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid">is_valid</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.check">check</a></code></li>
 </ul>
 </li>
 </ul>
@@ -310,22 +268,28 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <span>(</span><span>pattern: str)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Matches the input value against the provided regex</p></div>
+<div class="desc"><p>Matches the input value against the provided regex.</p>
+<h2 id="parameters">Parameters</h2>
+<p>pattern (str): Regexp pattern to match.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class RegexpValidator(AbstractArgumentValidator):
-    &#34;&#34;&#34;Matches the input value against the provided regex&#34;&#34;&#34;
+    &#34;&#34;&#34;
+    Matches the input value against the provided regex.
+
+    Parameters:
+        pattern (str): Regexp pattern to match.
+    &#34;&#34;&#34;
 
     def __init__(self, pattern: str):
         self._pattern = pattern
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
-        return re.match(self._pattern, value) is not None
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must match regexp pattern: {self._pattern}&#34;</code></pre>
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if re.match(self._pattern, value) is not None:
+            return ValidationResult(True)
+        return ValidationResult(False, f&#34;{name} must match regexp pattern: {self._pattern}&#34;)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -336,8 +300,7 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <ul class="hlist">
 <li><code><b><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a></b></code>:
 <ul class="hlist">
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message">invalid_message</a></code></li>
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid">is_valid</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.check">check</a></code></li>
 </ul>
 </li>
 </ul>
@@ -354,15 +317,12 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <pre><code class="python">class UUIDBytesValidator(AbstractArgumentValidator):
     &#34;&#34;&#34;Class that ensures the provided value is a valid UUID&#34;&#34;&#34;
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
         try:
             uuid.UUID(bytes=value)
         except (ValueError, TypeError):
-            return False
-        return True
-
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;{name} must be a valid UUID&#34;</code></pre>
+            return ValidationResult(False, f&#34;{name} must be a valid UUID&#34;)
+        return ValidationResult(True)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -373,11 +333,43 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <ul class="hlist">
 <li><code><b><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a></b></code>:
 <ul class="hlist">
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message">invalid_message</a></code></li>
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid">is_valid</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.check">check</a></code></li>
 </ul>
 </li>
 </ul>
+</dd>
+<dt id="grpc_argument_validator.argument_validators.ValidationResult"><code class="flex name class">
+<span>class <span class="ident">ValidationResult</span></span>
+<span>(</span><span>valid: bool, invalid_reason: Union[str, NoneType] = None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Contains results for validation check.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ValidationResult:
+    &#34;&#34;&#34;
+    Contains results for validation check.
+    &#34;&#34;&#34;
+
+    valid: bool
+    &#34;&#34;&#34;Whether the argument was valid.&#34;&#34;&#34;
+
+    invalid_reason: typing.Optional[str] = None
+    &#34;&#34;&#34;Reason for invalidity of the argument. Will be ``None`` if valid.&#34;&#34;&#34;</code></pre>
+</details>
+<h3>Class variables</h3>
+<dl>
+<dt id="grpc_argument_validator.argument_validators.ValidationResult.invalid_reason"><code class="name">var <span class="ident">invalid_reason</span> : Union[str, NoneType]</code></dt>
+<dd>
+<div class="desc"><p>Reason for invalidity of the argument. Will be <code>None</code> if valid.</p></div>
+</dd>
+<dt id="grpc_argument_validator.argument_validators.ValidationResult.valid"><code class="name">var <span class="ident">valid</span> : bool</code></dt>
+<dd>
+<div class="desc"><p>Whether the argument was valid.</p></div>
+</dd>
+</dl>
 </dd>
 </dl>
 </section>
@@ -398,8 +390,7 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 <li>
 <h4><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a></code></h4>
 <ul class="">
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.invalid_message">invalid_message</a></code></li>
-<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.is_valid">is_valid</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator.check" href="#grpc_argument_validator.argument_validators.AbstractArgumentValidator.check">check</a></code></li>
 </ul>
 </li>
 <li>
@@ -413,6 +404,13 @@ def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -&gt; b
 </li>
 <li>
 <h4><code><a title="grpc_argument_validator.argument_validators.UUIDBytesValidator" href="#grpc_argument_validator.argument_validators.UUIDBytesValidator">UUIDBytesValidator</a></code></h4>
+</li>
+<li>
+<h4><code><a title="grpc_argument_validator.argument_validators.ValidationResult" href="#grpc_argument_validator.argument_validators.ValidationResult">ValidationResult</a></code></h4>
+<ul class="">
+<li><code><a title="grpc_argument_validator.argument_validators.ValidationResult.invalid_reason" href="#grpc_argument_validator.argument_validators.ValidationResult.invalid_reason">invalid_reason</a></code></li>
+<li><code><a title="grpc_argument_validator.argument_validators.ValidationResult.valid" href="#grpc_argument_validator.argument_validators.ValidationResult.valid">valid</a></code></li>
+</ul>
 </li>
 </ul>
 </li>

--- a/docs/grpc_argument_validator/index.html
+++ b/docs/grpc_argument_validator/index.html
@@ -24,15 +24,16 @@
 <section id="section-intro">
 <p>Provides decorator to validate arguments in protobuf messages.</p>
 <p>Example:</p>
-<pre><code>from grpc_argument_validator import validate_args
-from grpc_argument_validator import AbstractArgumentValidator
+<pre><code>from google.protobuf.descriptor import FieldDescriptor
+from grpc_argument_validator import validate_args
+from grpc_argument_validator import AbstractArgumentValidator, ValidationResult
 
 class PathValidator(AbstractArgumentValidator):
-    def is_valid(self, value: Path, field_descriptor) -&gt; bool:
-        return len(value.points) &gt; 5
 
-    def invalid_message(self, name: str) -&gt; str:
-        return f&quot;path for '{name}' should be at least five points long&quot;
+    def check(self, name: str, value: Path, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if len(value.points) &gt; 5:
+            return ValidationResult(valid=True)
+        return ValidationResult(False, f&quot;path for '{name}' should be at least five points long&quot;)
 
 class RouteChecker(RouteCheckerServicer):
     @validate_args(
@@ -51,15 +52,16 @@ Provides decorator to validate arguments in protobuf messages.
 
 Example:
 ```
+from google.protobuf.descriptor import FieldDescriptor
 from grpc_argument_validator import validate_args
-from grpc_argument_validator import AbstractArgumentValidator
+from grpc_argument_validator import AbstractArgumentValidator, ValidationResult
 
 class PathValidator(AbstractArgumentValidator):
-    def is_valid(self, value: Path, field_descriptor) -&gt; bool:
-        return len(value.points) &gt; 5
 
-    def invalid_message(self, name: str) -&gt; str:
-        return f&#34;path for &#39;{name}&#39; should be at least five points long&#34;
+    def check(self, name: str, value: Path, field_descriptor: FieldDescriptor) -&gt; ValidationResult:
+        if len(value.points) &gt; 5:
+            return ValidationResult(valid=True)
+        return ValidationResult(False, f&#34;path for &#39;{name}&#39; should be at least five points long&#34;)
 
 class RouteChecker(RouteCheckerServicer):
     @validate_args(
@@ -72,6 +74,7 @@ class RouteChecker(RouteCheckerServicer):
 &#34;&#34;&#34;
 from .argument_validators import AbstractArgumentValidator
 from .argument_validators import RegexpValidator
+from .argument_validators import ValidationResult
 from .validate_args_decorator import validate_args</code></pre>
 </details>
 </section>

--- a/docs/grpc_argument_validator/index.html
+++ b/docs/grpc_argument_validator/index.html
@@ -35,12 +35,12 @@ class PathValidator(AbstractArgumentValidator):
             return ValidationResult(valid=True)
         return ValidationResult(False, f&quot;path for '{name}' should be at least five points long&quot;)
 
-class RouteChecker(RouteCheckerServicer):
+class RouteService(RouteCheckerServicer):
     @validate_args(
         non_empty=[&quot;tags&quot;, &quot;tags[]&quot;, &quot;path.points&quot;],
         validators={&quot;path&quot;: PathValidator()},
     )
-    def Check(self, request: Route, context: grpc.ServicerContext):
+    def Create(self, request: Route, context: grpc.ServicerContext):
         return BoolValue(value=True)
 </code></pre>
 <details class="source">
@@ -63,12 +63,12 @@ class PathValidator(AbstractArgumentValidator):
             return ValidationResult(valid=True)
         return ValidationResult(False, f&#34;path for &#39;{name}&#39; should be at least five points long&#34;)
 
-class RouteChecker(RouteCheckerServicer):
+class RouteService(RouteCheckerServicer):
     @validate_args(
         non_empty=[&#34;tags&#34;, &#34;tags[]&#34;, &#34;path.points&#34;],
         validators={&#34;path&#34;: PathValidator()},
     )
-    def Check(self, request: Route, context: grpc.ServicerContext):
+    def Create(self, request: Route, context: grpc.ServicerContext):
         return BoolValue(value=True)
 ```
 &#34;&#34;&#34;

--- a/docs/grpc_argument_validator/validate_args_decorator.html
+++ b/docs/grpc_argument_validator/validate_args_decorator.html
@@ -28,6 +28,7 @@
 </summary>
 <pre><code class="python">import functools
 import itertools
+import re
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -40,63 +41,6 @@ from grpc_argument_validator import AbstractArgumentValidator
 from grpc_argument_validator.argument_validators import NonDefaultValidator
 from grpc_argument_validator.argument_validators import NonEmptyValidator
 from grpc_argument_validator.argument_validators import UUIDBytesValidator
-
-
-def _recurse_validate(
-    message: Message,
-    name: str,
-    validators: List[AbstractArgumentValidator],
-    leading_parts_name: str = None,
-    is_optional: bool = False,
-):
-    errors = []
-    field_name_raw, *remaining_fields = name.split(&#34;.&#34;)
-    field_name = field_name_raw.rstrip(&#34;[]&#34;)
-    field_descriptor = message.DESCRIPTOR.fields_by_name[field_name]
-
-    full_name = field_name if leading_parts_name is None else f&#34;{leading_parts_name}.{field_name}&#34;
-    if (
-        field_descriptor.label != FieldDescriptor.LABEL_REPEATED
-        and field_descriptor.type == FieldDescriptor.TYPE_MESSAGE
-        and not message.HasField(field_name)
-    ):
-        if is_optional:
-            return []
-        return [f&#34;request must have {full_name}&#34;]
-
-    field_value = getattr(message, field_name)
-    if remaining_fields:
-        if field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
-            for i, elem in enumerate(field_value):
-                errors.extend(
-                    _recurse_validate(
-                        message=elem,
-                        name=&#34;.&#34;.join(remaining_fields),
-                        leading_parts_name=f&#34;{full_name}[{i}]&#34;,
-                        validators=validators,
-                        is_optional=is_optional,
-                    )
-                )
-        else:
-            errors.extend(
-                _recurse_validate(
-                    message=field_value,
-                    name=&#34;.&#34;.join(remaining_fields),
-                    leading_parts_name=full_name,
-                    validators=validators,
-                    is_optional=is_optional,
-                )
-            )
-    else:
-        for v in validators:
-            if field_name_raw.endswith(&#34;[]&#34;) and field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
-                for i, field_value_elem in enumerate(field_value):
-                    if not v.is_valid(field_value_elem, field_descriptor):
-                        errors.append(v.invalid_message(f&#34;{full_name}[{i}]&#34;))
-            else:
-                if not v.is_valid(field_value, field_descriptor):
-                    errors.append(v.invalid_message(full_name))
-    return errors
 
 
 def validate_args(
@@ -118,7 +62,8 @@ def validate_args(
     E.g. `foo.bar` where bar is a property of the Message in foo.
 
 
-    For lists the same notation can be used, for clarity `[]` can be added optionally. Both `foo.bar` and `foo[].bar` can be used, where bar is a property of the Message in the list foo.
+    For lists the same notation can be used, for clarity `[]` can be added optionally. Both `foo.bar` and `foo[].bar`
+    can be used, where bar is a property of the Message in the list foo.
 
         Parameters:
             has (Optional[List[str]]):
@@ -138,7 +83,8 @@ def validate_args(
             validators (Optional[Dict[str, AbstractArgumentValidator]]):
                 Dict mapping field names to validators
             optional_validators (Optional[Dict[str, AbstractArgumentValidator]]):
-                Dict mapping field names to validators, the fields can be None or validated using the specified validator
+                Dict mapping field names to validators, the fields can be None or validated using the specified
+                validator
 
         Returns:
             decorating_function (func): the decorating function wrapping the gRPC method function
@@ -170,6 +116,10 @@ def validate_args(
             optional_validators_value.keys(),
         )
     )
+    for field_name in field_names:
+        if not _is_valid_field_path(field_name):
+            raise ValueError(f&#34;Field name {field_name} does not adhere to Protobuf 3 language specification&#34;)
+
     if set(uuids_value + non_empty_value + non_default_value + list(validators_value.keys())).intersection(
         set(
             optional_uuids_value
@@ -213,7 +163,79 @@ def validate_args(
 
         return validate_wrapper
 
-    return decorating_function</code></pre>
+    return decorating_function
+
+
+def _recurse_validate(
+    message: Message,
+    name: str,
+    validators: List[AbstractArgumentValidator],
+    leading_parts_name: str = None,
+    is_optional: bool = False,
+):
+    errors = []
+    field_name_raw, *remaining_fields = name.split(&#34;.&#34;)
+    field_name = field_name_raw.rstrip(&#34;[]&#34;)
+
+    remaining_fields = [f for f in remaining_fields if f != &#34;&#34;]
+
+    if leading_parts_name is None and field_name == &#34;&#34;:
+        field_value = message
+        field_descriptor = message.DESCRIPTOR
+        full_name = message.DESCRIPTOR.name
+    else:
+        field_descriptor = message.DESCRIPTOR.fields_by_name[field_name]
+
+        full_name = field_name if leading_parts_name is None else f&#34;{leading_parts_name}.{field_name}&#34;
+        if (
+            field_descriptor.label != FieldDescriptor.LABEL_REPEATED
+            and field_descriptor.type == FieldDescriptor.TYPE_MESSAGE
+            and not message.HasField(field_name)
+        ):
+            if is_optional:
+                return []
+            return [f&#34;request must have {full_name}&#34;]
+
+        field_value = getattr(message, field_name)
+
+    if remaining_fields:
+        if field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
+            for i, elem in enumerate(field_value):
+                errors.extend(
+                    _recurse_validate(
+                        message=elem,
+                        name=&#34;.&#34;.join(remaining_fields),
+                        leading_parts_name=f&#34;{full_name}[{i}]&#34;,
+                        validators=validators,
+                        is_optional=is_optional,
+                    )
+                )
+        else:
+            errors.extend(
+                _recurse_validate(
+                    message=field_value,
+                    name=&#34;.&#34;.join(remaining_fields),
+                    leading_parts_name=full_name,
+                    validators=validators,
+                    is_optional=is_optional,
+                )
+            )
+    else:
+        for v in validators:
+            if field_name_raw.endswith(&#34;[]&#34;) and field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
+                for i, field_value_elem in enumerate(field_value):
+                    validation_result = v.check(f&#34;{full_name}[{i}]&#34;, field_value_elem, field_descriptor)
+                    if not validation_result.valid:
+                        errors.append(validation_result.invalid_reason)
+            else:
+                validation_result = v.check(full_name, field_value, field_descriptor)
+                if not validation_result.valid:
+                    errors.append(validation_result.invalid_reason)
+    return errors
+
+
+def _is_valid_field_path(path: str):
+    return re.match(r&#34;^(?:\.|\.?(?:[a-zA-Z][a-zA-Z_0-9]*\.)*(?:[a-zA-Z][a-zA-Z_0-9]*)(?:\[\])?)$&#34;, path) is not None</code></pre>
 </details>
 </section>
 <section>
@@ -224,13 +246,14 @@ def validate_args(
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="grpc_argument_validator.validate_args_decorator.validate_args"><code class="name flex">
-<span>def <span class="ident">validate_args</span></span>(<span>has: Optional[List[str]] = None, uuids: Optional[List[str]] = None, non_default: Optional[List[str]] = None, non_empty: Optional[List[str]] = None, optional_uuids: Optional[List[str]] = None, optional_non_empty: Optional[List[str]] = None, optional_non_default: Optional[List[str]] = None, validators: Optional[Dict[str, <a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="argument_validators.html#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a>]] = None, optional_validators: Optional[Dict[str, <a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="argument_validators.html#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a>]] = None) ‑> Callable</span>
+<span>def <span class="ident">validate_args</span></span>(<span>has: Union[List[str], NoneType] = None, uuids: Union[List[str], NoneType] = None, non_default: Union[List[str], NoneType] = None, non_empty: Union[List[str], NoneType] = None, optional_uuids: Union[List[str], NoneType] = None, optional_non_empty: Union[List[str], NoneType] = None, optional_non_default: Union[List[str], NoneType] = None, validators: Union[Dict[str, <a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="argument_validators.html#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a>], NoneType] = None, optional_validators: Union[Dict[str, <a title="grpc_argument_validator.argument_validators.AbstractArgumentValidator" href="argument_validators.html#grpc_argument_validator.argument_validators.AbstractArgumentValidator">AbstractArgumentValidator</a>], NoneType] = None) ‑> Callable</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Decorator to validate Message type arguments for gRPC methods.</p>
 <p>Subfields can be separated by a <code>.</code>.</p>
 <p>E.g. <code>foo.bar</code> where bar is a property of the Message in foo.</p>
-<p>For lists the same notation can be used, for clarity <code>[]</code> can be added optionally. Both <code>foo.bar</code> and <code>foo[].bar</code> can be used, where bar is a property of the Message in the list foo.</p>
+<p>For lists the same notation can be used, for clarity <code>[]</code> can be added optionally. Both <code>foo.bar</code> and <code>foo[].bar</code>
+can be used, where bar is a property of the Message in the list foo.</p>
 <pre><code>Parameters:
     has (Optional[List[str]]):
         Fields the Message should contain
@@ -249,7 +272,8 @@ def validate_args(
     validators (Optional[Dict[str, AbstractArgumentValidator]]):
         Dict mapping field names to validators
     optional_validators (Optional[Dict[str, AbstractArgumentValidator]]):
-        Dict mapping field names to validators, the fields can be None or validated using the specified validator
+        Dict mapping field names to validators, the fields can be None or validated using the specified
+        validator
 
 Returns:
     decorating_function (func): the decorating function wrapping the gRPC method function
@@ -277,7 +301,8 @@ Returns:
     E.g. `foo.bar` where bar is a property of the Message in foo.
 
 
-    For lists the same notation can be used, for clarity `[]` can be added optionally. Both `foo.bar` and `foo[].bar` can be used, where bar is a property of the Message in the list foo.
+    For lists the same notation can be used, for clarity `[]` can be added optionally. Both `foo.bar` and `foo[].bar`
+    can be used, where bar is a property of the Message in the list foo.
 
         Parameters:
             has (Optional[List[str]]):
@@ -297,7 +322,8 @@ Returns:
             validators (Optional[Dict[str, AbstractArgumentValidator]]):
                 Dict mapping field names to validators
             optional_validators (Optional[Dict[str, AbstractArgumentValidator]]):
-                Dict mapping field names to validators, the fields can be None or validated using the specified validator
+                Dict mapping field names to validators, the fields can be None or validated using the specified
+                validator
 
         Returns:
             decorating_function (func): the decorating function wrapping the gRPC method function
@@ -329,6 +355,10 @@ Returns:
             optional_validators_value.keys(),
         )
     )
+    for field_name in field_names:
+        if not _is_valid_field_path(field_name):
+            raise ValueError(f&#34;Field name {field_name} does not adhere to Protobuf 3 language specification&#34;)
+
     if set(uuids_value + non_empty_value + non_default_value + list(validators_value.keys())).intersection(
         set(
             optional_uuids_value

--- a/docs/grpc_argument_validator/validate_args_decorator.html
+++ b/docs/grpc_argument_validator/validate_args_decorator.html
@@ -29,8 +29,11 @@
 <pre><code class="python">import functools
 import itertools
 import re
+from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Iterable
+from typing import Iterator
 from typing import List
 from typing import Optional
 
@@ -181,7 +184,7 @@ def _recurse_validate(
 
     if leading_parts_name is None and field_name == &#34;&#34;:
         field_value = message
-        field_descriptor = message.DESCRIPTOR
+        field_descriptor: FieldDescriptor = message.DESCRIPTOR  # type: ignore
         full_name = message.DESCRIPTOR.name
     else:
         field_descriptor = message.DESCRIPTOR.fields_by_name[field_name]
@@ -200,7 +203,7 @@ def _recurse_validate(
 
     if remaining_fields:
         if field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
-            for i, elem in enumerate(field_value):
+            for i, elem in enumerate(field_value):  # type: ignore
                 errors.extend(
                     _recurse_validate(
                         message=elem,
@@ -223,7 +226,7 @@ def _recurse_validate(
     else:
         for v in validators:
             if field_name_raw.endswith(&#34;[]&#34;) and field_descriptor.label == FieldDescriptor.LABEL_REPEATED:
-                for i, field_value_elem in enumerate(field_value):
+                for i, field_value_elem in enumerate(field_value):  # type: ignore
                     validation_result = v.check(f&#34;{full_name}[{i}]&#34;, field_value_elem, field_descriptor)
                     if not validation_result.valid:
                         errors.append(validation_result.invalid_reason)

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,35 +1,35 @@
 from unittest.mock import MagicMock
 
 import grpc
+from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.wrappers_pb2 import BoolValue
 from grpc_argument_validator import AbstractArgumentValidator
 from grpc_argument_validator import validate_args
+from grpc_argument_validator import ValidationResult
 from tests.route_guide_protos.route_guide_pb2 import Path
 from tests.route_guide_protos.route_guide_pb2 import Route
 
 
 class PathValidator(AbstractArgumentValidator):
-    def is_valid(self, value: Path, field_descriptor) -> bool:
-        return len(value.points) > 5
+    def check(self, name: str, value: Path, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if len(value.points) > 5:
+            return ValidationResult(valid=True)
+        return ValidationResult(False, f"path for '{name}' should be at least five points long")
 
-    def invalid_message(self, name: str) -> str:
-        return f"path for '{name}' should be at least five points long"
 
-
-# Some class that implements a gRPC servicer
-class RouteChecker:
+class RouteService:
     @validate_args(
         non_empty=["tags", "tags[]", "path.points"], validators={"path": PathValidator()},
     )
-    def Check(self, request: Route, context: grpc.ServicerContext):
+    def Create(self, request: Route, context: grpc.ServicerContext):
         return BoolValue(value=True)
 
 
 if __name__ == "__main__":
-    checker = RouteChecker()
+    checker = RouteService()
 
     context = MagicMock()
     context.abort.side_effect = Exception("invalid arg")
 
     # this is not good
-    checker.Check(Route(path=Path(points=[])), context=context)
+    checker.Create(Route(path=Path(points=[])), context=context)

--- a/src/grpc_argument_validator/__init__.py
+++ b/src/grpc_argument_validator/__init__.py
@@ -3,25 +3,27 @@ Provides decorator to validate arguments in protobuf messages.
 
 Example:
 ```
+from google.protobuf.descriptor import FieldDescriptor
 from grpc_argument_validator import validate_args
-from grpc_argument_validator import AbstractArgumentValidator
+from grpc_argument_validator import AbstractArgumentValidator, ValidationResult
 
 class PathValidator(AbstractArgumentValidator):
-    def is_valid(self, value: Path, field_descriptor) -> bool:
-        return len(value.points) > 5
 
-    def invalid_message(self, name: str) -> str:
-        return f"path for '{name}' should be at least five points long"
+    def check(self, name: str, value: Path, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if len(value.points) > 5:
+            return ValidationResult(valid=True)
+        return ValidationResult(False, f"path for '{name}' should be at least five points long")
 
-class RouteChecker(RouteCheckerServicer):
+class RouteService(RouteCheckerServicer):
     @validate_args(
         non_empty=["tags", "tags[]", "path.points"],
         validators={"path": PathValidator()},
     )
-    def Check(self, request: Route, context: grpc.ServicerContext):
+    def Create(self, request: Route, context: grpc.ServicerContext):
         return BoolValue(value=True)
 ```
 """
 from .argument_validators import AbstractArgumentValidator
 from .argument_validators import RegexpValidator
+from .argument_validators import ValidationResult
 from .validate_args_decorator import validate_args

--- a/src/grpc_argument_validator/argument_validators.py
+++ b/src/grpc_argument_validator/argument_validators.py
@@ -2,8 +2,22 @@ import abc
 import re
 import typing
 import uuid
+from dataclasses import dataclass
 
 from google.protobuf.descriptor import FieldDescriptor
+
+
+@dataclass
+class ValidationResult:
+    """
+    Contains results for validation check.
+    """
+
+    valid: bool
+    """Whether the argument was valid."""
+
+    invalid_reason: typing.Optional[str] = None
+    """Reason for invalidity of the argument. Will be ``None`` if valid."""
 
 
 class AbstractArgumentValidator(abc.ABC):
@@ -12,29 +26,17 @@ class AbstractArgumentValidator(abc.ABC):
     """
 
     @abc.abstractmethod
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -> bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -> ValidationResult:
         """
         Returns a validation bool of the given value and field_descriptor
 
             Parameters:
+                name (str): Name for the field to be used in invalid reason messages.
                 value (typing.Any): The value to be validated
                 field_descriptor (FieldDescriptor): The protobuf field descriptor of the given value
 
             Returns:
-                is_valid (bool): validation bool for the given value
-        """
-        pass
-
-    @abc.abstractmethod
-    def invalid_message(self, name: str) -> str:
-        """
-        Returns a validation message for the given field name
-
-            Parameters:
-                name (str): Name of the validated field
-
-            Returns:
-                message (str): message describing the constraints of the validator
+                result (ValidationResult): validation bool for the given value
         """
         pass
 
@@ -42,45 +44,44 @@ class AbstractArgumentValidator(abc.ABC):
 class UUIDBytesValidator(AbstractArgumentValidator):
     """Class that ensures the provided value is a valid UUID"""
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -> bool:
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -> ValidationResult:
         try:
             uuid.UUID(bytes=value)
         except (ValueError, TypeError):
-            return False
-        return True
-
-    def invalid_message(self, name: str) -> str:
-        return f"{name} must be a valid UUID"
+            return ValidationResult(False, f"{name} must be a valid UUID")
+        return ValidationResult(True)
 
 
 class NonDefaultValidator(AbstractArgumentValidator):
     """Ensures the provided value is not the default value for this field type"""
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -> bool:
-        return value != field_descriptor.default_value
-
-    def invalid_message(self, name: str) -> str:
-        return f"{name} must have non-default value"
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if value != field_descriptor.default_value:
+            return ValidationResult(True)
+        return ValidationResult(False, f"{name} must have non-default value")
 
 
 class NonEmptyValidator(AbstractArgumentValidator):
     """Ensures the provided value is non-empty"""
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -> bool:
-        return len(value) > 0
-
-    def invalid_message(self, name: str) -> str:
-        return f"{name} must be non-empty"
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if len(value) > 0:
+            return ValidationResult(True)
+        return ValidationResult(False, f"{name} must be non-empty")
 
 
 class RegexpValidator(AbstractArgumentValidator):
-    """Matches the input value against the provided regex"""
+    """
+    Matches the input value against the provided regex.
+
+    Parameters:
+        pattern (str): Regexp pattern to match.
+    """
 
     def __init__(self, pattern: str):
         self._pattern = pattern
 
-    def is_valid(self, value: typing.Any, field_descriptor: FieldDescriptor) -> bool:
-        return re.match(self._pattern, value) is not None
-
-    def invalid_message(self, name: str) -> str:
-        return f"{name} must match regexp pattern: {self._pattern}"
+    def check(self, name: str, value: typing.Any, field_descriptor: FieldDescriptor) -> ValidationResult:
+        if re.match(self._pattern, value) is not None:
+            return ValidationResult(True)
+        return ValidationResult(False, f"{name} must match regexp pattern: {self._pattern}")

--- a/src/grpc_argument_validator/validate_args_decorator.py
+++ b/src/grpc_argument_validator/validate_args_decorator.py
@@ -1,11 +1,8 @@
 import functools
 import itertools
 import re
-from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import Optional
 

--- a/src/grpc_argument_validator/validate_args_decorator.py
+++ b/src/grpc_argument_validator/validate_args_decorator.py
@@ -90,7 +90,11 @@ def validate_args(
     )
     for field_name in field_names:
         if not _is_valid_field_path(field_name):
-            raise ValueError(f"Field name {field_name} does not adhere to Protobuf 3 language specification")
+            raise ValueError(
+                f"Field name {field_name} does not adhere to Protobuf 3 language specification, "
+                f"may be prepended with '.' or appended with '[]'. Alternatively, '.' should be used for "
+                f"performing validations on the 'root' proto."
+            )
 
     if set(uuids_value + non_empty_value + non_default_value + list(validators_value.keys())).intersection(
         set(


### PR DESCRIPTION
- Simplifies validator API
- Allows checks on 'root' level proto by using `.` as the name of the field to be validated
- Checks name of the fields provided against protobuf language specification
- Updates tests for all of the above